### PR TITLE
Show user matches on home page

### DIFF
--- a/create-match.html
+++ b/create-match.html
@@ -19,11 +19,15 @@
         <button id="flow-test">Test Flow</button>
     </nav>
     <form id="match-form">
-        <label>Title <input type="text" required></label>
-        <label>Location <input type="text"></label>
-        <label>Date &amp; Time <input type="datetime-local"></label>
-        <label>Players (comma separated) <input type="text" placeholder="e.g. Alice,Bob"></label>
-        <label>Notes <textarea></textarea></label>
+        <label>Title <input id="match-title" type="text" required></label>
+        <label>Location <input id="match-location" type="text"></label>
+        <label>Date &amp; Time <input id="match-datetime" type="datetime-local"></label>
+        <label>Player
+            <input id="player-input" type="text" placeholder="e.g. Alice">
+            <button id="add-player" type="button">Add</button>
+        </label>
+        <ul id="player-list"></ul>
+        <label>Notes <textarea id="match-notes"></textarea></label>
         <button type="submit">Create Match</button>
     </form>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -23,12 +23,91 @@ if (createFirst) {
   });
 }
 
-// Handle create match form submission
+// Utility functions for storing matches in localStorage
+function getStoredMatches() {
+  try {
+    return JSON.parse(localStorage.getItem('matches')) || [];
+  } catch (e) {
+    return [];
+  }
+}
+
+function addMatch(match) {
+  const matches = getStoredMatches();
+  matches.push(match);
+  localStorage.setItem('matches', JSON.stringify(matches));
+}
+
+// Render matches on the main page
+const matchesContainer = document.getElementById('matches');
+if (matchesContainer) {
+  const matches = getStoredMatches();
+  const empty = document.getElementById('empty-state');
+  if (matches.length === 0) {
+    if (empty) empty.style.display = 'block';
+  } else {
+    if (empty) empty.style.display = 'none';
+    matches.forEach(m => {
+      const card = document.createElement('div');
+      card.className = 'match-card';
+      card.innerHTML = `
+        <h3>${m.title}</h3>
+        <p>${m.location} | ${m.datetime ? new Date(m.datetime).toLocaleString() : ''}</p>
+        <p>Players: ${m.players.join(', ')}</p>
+        <p>${m.notes}</p>`;
+      matchesContainer.appendChild(card);
+    });
+  }
+}
+
+// Handle player list building and match form submission
 const matchForm = document.getElementById('match-form');
+const playerInput = document.getElementById('player-input');
+const addPlayerBtn = document.getElementById('add-player');
+const playerList = document.getElementById('player-list');
+const players = [];
+
+function renderPlayers() {
+  if (!playerList) return;
+  playerList.innerHTML = '';
+  players.forEach((name, idx) => {
+    const li = document.createElement('li');
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.textContent = 'x';
+    remove.addEventListener('click', () => {
+      players.splice(idx, 1);
+      renderPlayers();
+    });
+    li.textContent = name + ' ';
+    li.appendChild(remove);
+    playerList.appendChild(li);
+  });
+}
+
+if (addPlayerBtn && playerInput) {
+  addPlayerBtn.addEventListener('click', () => {
+    const name = playerInput.value.trim();
+    if (name) {
+      players.push(name);
+      playerInput.value = '';
+      renderPlayers();
+      playerInput.focus();
+    }
+  });
+}
+
 if (matchForm) {
   matchForm.addEventListener('submit', e => {
     e.preventDefault();
-    alert('Match created! (placeholder)');
+    const newMatch = {
+      title: document.getElementById('match-title').value.trim(),
+      location: document.getElementById('match-location').value.trim(),
+      datetime: document.getElementById('match-datetime').value,
+      players: players.slice(),
+      notes: document.getElementById('match-notes').value.trim()
+    };
+    addMatch(newMatch);
     window.location.href = 'index.html';
   });
 }

--- a/style.css
+++ b/style.css
@@ -71,3 +71,26 @@ button {
     background: #111;
     color: #eee;
 }
+
+.match-card {
+    background: #fff;
+    border: 1px solid #ccc;
+    padding: 10px;
+    margin-bottom: 10px;
+}
+
+#player-list {
+    list-style: none;
+    padding: 0;
+}
+
+#player-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 5px;
+}
+
+#player-list button {
+    margin-left: 10px;
+}


### PR DESCRIPTION
## Summary
- attach IDs to create match form fields
- save created matches to localStorage and display them on the index page
- add simple styling for match cards
- allow players to be added individually in the match form

## Testing
- `npm test` *(fails: package.json missing)*
- `npx eslint .` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881fa7fb5e48333ba5c98285093cf07