### PR TITLE
Add Google sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a simple prototype for an application that helps player
 ## Pages
 - **index.html** – Main page with search and filter controls. Displays an empty state encouraging creation of the first match.
 - **create-match.html** – Form for creating a new match with title, location, players, and notes fields.
-- **login.html** – Basic login form with email/password fields and a placeholder link for Google sign‑in.
+- **login.html** – Login form supporting email/password along with a real Google sign‑in button (update `YOUR_GOOGLE_CLIENT_ID` in `script.js`).
 - **signup.html** – Sign‑up form requesting name, email, and password confirmation.
 - **settings.html** – Shows user information and allows switching between light and dark themes. Includes placeholder export/import buttons.
 

--- a/login.html
+++ b/login.html
@@ -24,7 +24,10 @@
         <p><a href="#">Forgot password?</a></p>
         <button type="submit">Log In</button>
     </form>
-    <button id="google-signin">Sign in with Google</button>
+    <div id="google-signin"></div>
     <p>No account? <a href="signup.html">Sign up</a></p>
+
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -131,3 +131,31 @@ if (new URLSearchParams(location.search).has('flow')) {
     setTimeout(() => nextTrigger.click(), 1000);
   }
 }
+
+// Google Sign-In setup for login page
+const gSignInDiv = document.getElementById('google-signin');
+if (gSignInDiv && window.google && window.google.accounts && window.google.accounts.id) {
+  google.accounts.id.initialize({
+    client_id: 'YOUR_GOOGLE_CLIENT_ID',
+    callback: handleCredentialResponse
+  });
+  google.accounts.id.renderButton(gSignInDiv, { theme: 'outline', size: 'large' });
+}
+
+function handleCredentialResponse(response) {
+  try {
+    const data = parseJwt(response.credential);
+    alert(`Signed in as ${data.name || data.email}`);
+    localStorage.setItem('user', JSON.stringify(data));
+    window.location.href = 'index.html';
+  } catch (e) {
+    alert('Google sign-in failed');
+  }
+}
+
+function parseJwt(token) {
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const json = decodeURIComponent(atob(base64).split('').map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join(''));
+  return JSON.parse(json);
+}


### PR DESCRIPTION
## Summary
- add actual Google sign-in button on login page
- load Google sign-in library and hook it up in `script.js`
- document the new sign-in setup in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6881feb215cc8333ab74a5453cf238f9